### PR TITLE
OpenSSL 1.1 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,16 @@ Description
 This library requires an nginx build with OpenSSL,
 the [ngx_lua module](http://wiki.nginx.org/HttpLuaModule), and [LuaJIT 2.0](http://luajit.org/luajit.html).
 
+On 2017-12-07, I (Adam Cecile) added OpenSSL 1.1 support that brings Debian Stretch out of the box experience.
+Sadly there's no way to determine OpenSSL through FFI C-bindings so I had to use an environment variable to trigger legacy code.
+
+In top nginx configuration file add
+```
+env HMAC_USE_LEGACY_OPENSSL_API=1;
+```
+Otherwise it will use OpenSSL 1.1 calls.
+
+
 Synopsis
 ========
 

--- a/lib/resty/string.lua
+++ b/lib/resty/string.lua
@@ -1,0 +1,40 @@
+-- Copyright (C) by Yichun Zhang (agentzh)
+
+
+local ffi = require "ffi"
+local ffi_new = ffi.new
+local ffi_str = ffi.string
+local C = ffi.C
+--local setmetatable = setmetatable
+--local error = error
+local tonumber = tonumber
+
+
+local _M = { _VERSION = '0.10' }
+
+
+ffi.cdef[[
+typedef unsigned char u_char;
+
+u_char * ngx_hex_dump(u_char *dst, const u_char *src, size_t len);
+
+intptr_t ngx_atoi(const unsigned char *line, size_t n);
+]]
+
+local str_type = ffi.typeof("uint8_t[?]")
+
+
+function _M.to_hex(s)
+    local len = #s * 2
+    local buf = ffi_new(str_type, len)
+    C.ngx_hex_dump(buf, s, #s)
+    return ffi_str(buf, len)
+end
+
+
+function _M.atoi(s)
+    return tonumber(C.ngx_atoi(s, #s))
+end
+
+
+return _M


### PR DESCRIPTION
Hi,

I added OpenSSL 1.1 support. The code is probably ugly but I couldn't find a way to figure out if I need to use legacy API through FFI. OpenSSL version is set in C headers throught a #defines statement which cannot be used from FFI so I guess this is the only way...

Anyway, this new patched code works as expected for use on Debian Stretch :-)

Adam