### PR TITLE
chore: add $(DESTDIR) for packing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ all:
 	@test -f resty_modules/lualib/resty/string.lua || curl -s -o resty_modules/lualib/resty/string.lua https://raw.githubusercontent.com/openresty/lua-resty-string/master/lib/resty/string.lua
 
 install: all
-	$(INSTALL) -d $(LUA_LIB_DIR)/resty
-	$(INSTALL) resty_modules/lualib/resty/*.lua $(LUA_LIB_DIR)/resty
-	$(INSTALL) lib/resty/*.lua $(LUA_LIB_DIR)/resty
+	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty
+	$(INSTALL) resty_modules/lualib/resty/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty
+	$(INSTALL) lib/resty/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty
 
 test: install
-	LUA_PATH="$(LUA_LIB_DIR)/?.lua;;" TEST_NGINX_USE_VALGRIND=$(VALGRIND) TEST_NGINX_CHECK_LEAK=$(CHECK_LEAK) TEST_NGINX_LOAD_MODULES="$(MODULES)" prove -I../test-nginx/lib -r t
+	LUA_PATH="$(DESTDIR)$(LUA_LIB_DIR)/?.lua;;" TEST_NGINX_USE_VALGRIND=$(VALGRIND) TEST_NGINX_CHECK_LEAK=$(CHECK_LEAK) TEST_NGINX_LOAD_MODULES="$(MODULES)" prove -I../test-nginx/lib -r t


### PR DESCRIPTION
@jkeys089 hihi, I think we should add $(DESTDIR) like other module? Such as https://github.com/openresty/lua-resty-mysql/blob/master/Makefile#L13. So we can pack this module to a special path(for dpkg or rpmbuild) more convenient.